### PR TITLE
Separate triggers for LEC / LCS to send at different times

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export const fetchThisWeeksEvents = async (week: Date = new Date()) => {
   const page = await browser.newPage();
 
   const today = DateTime.fromJSDate(week);
-  const weekInterval = Interval.after(today, { days: 6 });
+  const weekInterval = Interval.after(today, { days: 7 });
 
   let thisWeeksEvents = [];
 
@@ -48,11 +48,13 @@ export const fetchThisWeeksEvents = async (week: Date = new Date()) => {
   return thisWeeksEvents;
 };
 
-export const handler = async (): Promise<any> => {
+export const handler = async (event: { league: LeagueName }): Promise<any> => {
+  const { league } = event;
+
   const thisWeeksEvents = await fetchThisWeeksEvents();
 
   if (thisWeeksEvents.length > 0) {
-    await sendDiscordWebhook(thisWeeksEvents);
+    await sendDiscordWebhook(thisWeeksEvents, league);
 
     return {
       statusCode: 200,

--- a/src/sendDiscordWebhook.ts
+++ b/src/sendDiscordWebhook.ts
@@ -56,7 +56,7 @@ const sendMessage = async (leagueEvents: Event[], webhookURL) => {
   await axios.post(webhookURL, { content: message });
 };
 
-export default async (thisWeeksEvents: Event[]) => {
+export default async (thisWeeksEvents: Event[], league: LeagueName) => {
   if (process.env.NODE_ENV !== "production") {
     dotenv.config();
   }
@@ -64,13 +64,18 @@ export default async (thisWeeksEvents: Event[]) => {
   const LCSWebhookURL = process.env.LCS_WEBHOOK_URL;
   const LECWebhookURL = process.env.LEC_WEBHOOK_URL;
 
-  await sendMessage(
-    thisWeeksEvents.filter((event) => event.league.name === LeagueName.LCS),
-    LCSWebhookURL
-  );
-
-  await sendMessage(
-    thisWeeksEvents.filter((event) => event.league.name === LeagueName.LEC),
-    LECWebhookURL
-  );
+  switch (league) {
+    case LeagueName.LCS:
+      await sendMessage(
+        thisWeeksEvents.filter((event) => event.league.name === LeagueName.LCS),
+        LCSWebhookURL
+      );
+      break;
+    case LeagueName.LEC:
+      await sendMessage(
+        thisWeeksEvents.filter((event) => event.league.name === LeagueName.LEC),
+        LECWebhookURL
+      );
+      break;
+  }
 };

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,11 +1,12 @@
 // Run the logic that would run in the lambda locally
-import { fetchThisWeeksEvents } from "./index";
+import { fetchThisWeeksEvents, LeagueName } from "./index";
 import sendDiscordWebhooks from "./sendDiscordWebhook";
 const testSend = async () => {
   const thisWeeksEvents = await fetchThisWeeksEvents(
-    new Date("January 23, 2023")
+    new Date("January 17, 2023")
   );
-  sendDiscordWebhooks(thisWeeksEvents);
+  sendDiscordWebhooks(thisWeeksEvents, LeagueName.LCS);
+  sendDiscordWebhooks(thisWeeksEvents, LeagueName.LEC);
 };
 
 testSend();


### PR DESCRIPTION
Have 2 different scheduled rules now, one for trigger on a certain day for LCS and another for LEC. Thus changed the logic to take a league param that decided which webhook to call